### PR TITLE
Made upload process work for Netlify without problem

### DIFF
--- a/library/StaticHtmlOutput.php
+++ b/library/StaticHtmlOutput.php
@@ -728,14 +728,14 @@ class StaticHtmlOutput {
 
         try {
             $response = $client->request('POST', '/api/v1/sites/' . $netlifySiteID . '.netlify.com/deploys', [
+                    'headers'  => [
+                        'Content-Type' => 'application/zip',
+                        'Authorization' => 'Bearer ' . $netlifyPersonalAccessToken
+                    ],
                     'multipart' => [
                     [
                     'name'     => 'required_for_guzzle_only',
                     'contents' => fopen($archiveName . '.zip', 'r'),
-                    'headers'  => [
-                    'Content-Type' => 'application/zip',
-                    'Authorization' => 'Bearer ' . $netlifyPersonalAccessToken
-                    ]
                     ]
                     ]
             ]);

--- a/library/StaticHtmlOutput.php
+++ b/library/StaticHtmlOutput.php
@@ -732,12 +732,7 @@ class StaticHtmlOutput {
                         'Content-Type' => 'application/zip',
                         'Authorization' => 'Bearer ' . $netlifyPersonalAccessToken
                     ],
-                    'multipart' => [
-                    [
-                    'name'     => 'required_for_guzzle_only',
-                    'contents' => fopen($archiveName . '.zip', 'r'),
-                    ]
-                    ]
+                    'body' => fopen($archiveName . '.zip', 'rb')
             ]);
         } catch (Exception $e) {
             file_put_contents($_SERVER['exportLog'], $e , FILE_APPEND | LOCK_EX);


### PR DESCRIPTION
1) Resolved 401 Unauthorized error by moving header description outside of multipart description

Error which I got on WP-admin screen of this tool

##################
GuzzleHttp\Exception\ClientException: Client error: POST https://api.netlify.com/api/v1/sites/vpsaws.netlify.com/deploys resulted in a 401 Unauthorized response in /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/guzzle/src/Exception/RequestException.php:113

Stack trace:

#0 /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/guzzle/src/Middleware.php(65): GuzzleHttp\Exception\RequestException::create(Object(GuzzleHttp\Psr7\Request), Object(GuzzleHttp\Psr7\Response))

#1 /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/promises/src/Promise.php(203): GuzzleHttp\Middleware::GuzzleHttp\{closure}(Object(GuzzleHttp\Psr7\Response))

#2 /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/promises/src/Promise.php(156): GuzzleHttp\Promise\Promise::callHandler(1, Object(GuzzleHttp\Psr7\Response), Array)

#3 /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/promises/src/TaskQueue.php(47): GuzzleHttp\Promise\Promise::GuzzleHttp\Promise\{closure}()

#4 /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/promises/src/Promise.php(246): GuzzleHttp\Promise\TaskQueue->run(true)

#5 /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/promises/src/Promise.php(223): GuzzleHttp\Promise\Promise->invokeWaitFn()

#6 /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/promises/src/Promise.php(267): GuzzleHttp\Promise\Promise->waitIfPending()

#7 /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/promises/src/Promise.php(225): GuzzleHttp\Promise\Promise->invokeWaitList()

#8 /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/promises/src/Promise.php(62): GuzzleHttp\Promise\Promise->waitIfPending()

#9 /var/www/web/app/plugins/static-html-output-plugin/library/Github/guzzlehttp/guzzle/src/Client.php(131): GuzzleHttp\Promise\Promise->wait()

#10 /var/www/web/app/plugins/static-html-output-plugin/library/StaticHtmlOutput.php(632): GuzzleHttp\Client->request('POST', '/api/v1/sites/v...', Array)

#11 /var/www/web/app/plugins/static-html-output-plugin/library/StaticHtmlOutput.php(262): StaticHtmlOutput->_generateArchive()

#12 /var/www/web/app/plugins/static-html-output-plugin/wp-static-html-output.php(42): StaticHtmlOutput->genArch()

#13 /var/www/web/wp/wp-includes/class-wp-hook.php(286): generate_archive('')

#14 /var/www/web/wp/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters('', Array)

#15 /var/www/web/wp/wp-includes/plugin.php(453): WP_Hook->do_action(Array)

#16 /var/www/web/wp/wp-admin/admin-ajax.php(97): do_action('wp_ajax_generat...')
##################


2) Resolved failure of uploading of zip file to Netlify

Error on netlify's deployment screen
##################
Production: master@HEADFAILED
Error extracting zip: undefined method name for nil:NilClass
##################